### PR TITLE
remove db provisioning from main.tf

### DIFF
--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -103,30 +103,7 @@ resource "aws_iam_role_policy_attachment" "lambda_secretsmanager" {
   policy_arn = "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
 }
 
-# DynamoDB Tables
-resource "aws_dynamodb_table" "issuers" {
-  name         = "${local.env_prefix}-db-issuers"
-  billing_mode = "PAY_PER_REQUEST"
 
-  hash_key = "sub_name"
-
-  attribute {
-    name = "sub_name"
-    type = "S"
-  }
-}
-
-resource "aws_dynamodb_table" "registry_public_keys" {
-  name         = "${local.env_prefix}-db-registry-public-keys"
-  billing_mode = "PAY_PER_REQUEST"
-
-  hash_key = "key_id"
-
-  attribute {
-    name = "key_id"
-    type = "S"
-  }
-}
 
 # API Gateway
 resource "aws_apigatewayv2_api" "issuer_registry" {


### PR DESCRIPTION
Taking the dynamo db provisioning out of the terraform script so we don't accidentally provision multiple dbs or overwrite the existing db when applying other terraform provisioning (like rebuilding the lamda).

Will instead modify the README to explain how to create the four dynamo dbs using the aws cli.