### PR TITLE
Revert "remove db provisioning from main.tf"

### DIFF
--- a/modules/environment/main.tf
+++ b/modules/environment/main.tf
@@ -103,7 +103,30 @@ resource "aws_iam_role_policy_attachment" "lambda_secretsmanager" {
   policy_arn = "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
 }
 
+# DynamoDB Tables
+resource "aws_dynamodb_table" "issuers" {
+  name         = "${local.env_prefix}-db-issuers"
+  billing_mode = "PAY_PER_REQUEST"
 
+  hash_key = "sub_name"
+
+  attribute {
+    name = "sub_name"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "registry_public_keys" {
+  name         = "${local.env_prefix}-db-registry-public-keys"
+  billing_mode = "PAY_PER_REQUEST"
+
+  hash_key = "key_id"
+
+  attribute {
+    name = "key_id"
+    type = "S"
+  }
+}
 
 # API Gateway
 resource "aws_apigatewayv2_api" "issuer_registry" {


### PR DESCRIPTION
Reverts digitalcredentials/dcc-members-oidf#58

Reverting this for now because it turns out not to be so simple as simply removing the db provisioning config from main.tf

Will also have to remove the provisioned db tables from terraform's managed state as described here:

https://stackoverflow.com/questions/61297480/how-can-i-remove-a-resource-from-terraform-state
https://developer.hashicorp.com/terraform/cli/commands/state/rm

Because Terraform provisioned the tables, the db is therefor one of terraforms managed resources, and terraform expects the provisioning definition to remain in main.tf - if it isn't there, terraform assumes that means we want to delete the DB.

